### PR TITLE
Using black profile for isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        args: [--filter-files]
+        args: ["--filter-files", "--profile=black"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.3.0
     hooks:


### PR DESCRIPTION
Added argument "--profile=black" to isort in .pre-commit-config.yaml.